### PR TITLE
Fix: Migrate use of hashValues to Object.hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,3 +310,7 @@ Update dependency.
 ## [1.6.6] - 05.12.2023
 
 Update dependency.
+
+## [2.0.0] - 12.12.2024
+
+Breaking change: Fix: Migrate use of hashValues to Object.hash api which has been the latest standard since Dart 2.14.0

--- a/lib/src/shape_borders/rectangle.dart
+++ b/lib/src/shape_borders/rectangle.dart
@@ -251,5 +251,5 @@ class RectangleShapeBorder extends OutlinedShapeBorder {
   }
 
   @override
-  int get hashCode => hashValues(border, cornerStyles, borderRadius);
+  int get hashCode => Object.hash(border, cornerStyles, borderRadius);
 }

--- a/lib/src/shape_borders/rounded_rectangle.dart
+++ b/lib/src/shape_borders/rounded_rectangle.dart
@@ -324,5 +324,5 @@ class RoundedRectangleShapeBorder extends FilledBorderShapeBorder {
   }
 
   @override
-  int get hashCode => hashValues(borderSides, borderRadius);
+  int get hashCode => Object.hash(borderSides, borderRadius);
 }

--- a/lib/src/ui_data_classes/dynamic_border_radius.dart
+++ b/lib/src/ui_data_classes/dynamic_border_radius.dart
@@ -50,7 +50,7 @@ class DynamicRadius {
   }
 
   @override
-  int get hashCode => hashValues(x, y);
+  int get hashCode => Object.hash(x, y);
 }
 
 class DynamicBorderRadius {
@@ -125,5 +125,5 @@ class DynamicBorderRadius {
   }
 
   @override
-  int get hashCode => hashValues(topLeft, topRight, bottomLeft, bottomRight);
+  int get hashCode => Object.hash(topLeft, topRight, bottomLeft, bottomRight);
 }

--- a/lib/src/ui_data_classes/dynamic_border_side.dart
+++ b/lib/src/ui_data_classes/dynamic_border_side.dart
@@ -129,7 +129,8 @@ class DynamicBorderSide {
         color: Color.lerp(a.color, b.color, t)!,
         gradient: Gradient.lerp(a.gradient, b.gradient, t),
         width: width,
-        style: a.style, // == b.style
+        style: a.style,
+        // == b.style
         begin: Dimension.lerp(a.begin, b.begin, t),
         end: a.end == null && b.end == null
             ? null
@@ -190,6 +191,6 @@ class DynamicBorderSide {
   }
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
       color, gradient, width, style, begin, end, shift, strokeJoin, strokeCap);
 }

--- a/lib/src/ui_data_classes/dynamic_offset.dart
+++ b/lib/src/ui_data_classes/dynamic_offset.dart
@@ -38,7 +38,7 @@ class DynamicOffset {
   }
 
   @override
-  int get hashCode => hashValues(dx, dy);
+  int get hashCode => Object.hash(dx, dy);
 
   @override
   bool operator ==(dynamic other) {

--- a/lib/src/ui_data_classes/shape_shadow.dart
+++ b/lib/src/ui_data_classes/shape_shadow.dart
@@ -139,7 +139,7 @@ class ShapeShadow extends ui.Shadow {
 
   @override
   int get hashCode =>
-      hashValues(color, gradient, offset, blurRadius, spreadRadius, blurStyle);
+      Object.hash(color, gradient, offset, blurRadius, spreadRadius, blurStyle);
 
   @override
   String toString() =>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.19.0"
   dimension:
     dependency: "direct main"
     description:
@@ -83,51 +83,67 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      name: leak_tracker
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "10.0.7"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.8"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -140,26 +156,26 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -172,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -184,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.3.0"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
-  flutter: ">=2.10.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.6.6
 repository: https://github.com/KevinVan720/morphable_shape
 
 environment:
-  sdk: ">=2.13.0 <4.0.0"
+  sdk: ">=2.14.0 <4.0.0"
   flutter: ">=2.10.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: morphable_shape
 description: A Flutter package for creating various shapes that are responsive and can morph betweem each other.
-version: 1.6.6
+version: 2.0.0
 repository: https://github.com/KevinVan720/morphable_shape
 
 environment:


### PR DESCRIPTION
Flutter's latest stable has removed the method hashValues.

This PR fixes that to use Object.hash method