### PR TITLE
fixes after flutter 3.27.0 upgrade issues

### DIFF
--- a/lib/preset_shape_map.dart
+++ b/lib/preset_shape_map.dart
@@ -1,4 +1,3 @@
-import 'package:dimension/dimension.dart';
 import 'package:morphable_shape/morphable_shape.dart';
 
 ///A collection of predefined shapes, grouped into maps

--- a/lib/src/animated_decorated_shadowd_shape.dart
+++ b/lib/src/animated_decorated_shadowd_shape.dart
@@ -1,9 +1,7 @@
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:animated_box_decoration/animated_box_decoration.dart';
 import 'package:morphable_shape/morphable_shape.dart';
-import 'package:morphable_shape/src/dynamic_path/dynamic_path_morph.dart';
 
 class ListShapeShadowTween extends Tween<List<ShapeShadow>?> {
   ListShapeShadowTween({

--- a/lib/src/decorated_shadowed_shape.dart
+++ b/lib/src/decorated_shadowed_shape.dart
@@ -166,7 +166,7 @@ class _ShapeBorderPaint extends StatelessWidget {
   const _ShapeBorderPaint({
     this.child,
     this.shape,
-    this.borderOnForeground = true,
+    this.borderOnForeground = false,
   });
 
   final Widget? child;
@@ -189,6 +189,7 @@ class _ShapeBorderPaint extends StatelessWidget {
 
 class _ShapeBorderPainter extends CustomPainter {
   _ShapeBorderPainter(this.border, this.textDirection);
+
   final ShapeBorder? border;
   final TextDirection? textDirection;
 

--- a/lib/src/dynamic_path/dynamic_path_morph.dart
+++ b/lib/src/dynamic_path/dynamic_path_morph.dart
@@ -1,9 +1,4 @@
-import 'dart:math';
-import 'dart:ui';
 
-import 'package:flutter/animation.dart';
-import 'package:flutter/painting.dart';
-import 'package:flutter/rendering.dart';
 import 'package:morphable_shape/src/common_includes.dart';
 import 'package:morphable_shape/src/dynamic_path/border_paths.dart';
 

--- a/lib/src/shape_borders/morph.dart
+++ b/lib/src/shape_borders/morph.dart
@@ -1,7 +1,5 @@
-import 'dart:ui';
 
 import 'package:morphable_shape/src/common_includes.dart';
-import 'package:morphable_shape/src/dynamic_path/dynamic_path_morph.dart';
 
 ///this class should only be called by a morphShapeTween
 ///Use PathMorph to morph between two shapes
@@ -326,5 +324,6 @@ class MorphShapeBorder extends MorphableShapeBorder {
         return Gradient.lerp(beginGradient, endGradient, t);
       }
     }
+    return null;
   }
 }

--- a/lib/src/shape_borders/rectangle.dart
+++ b/lib/src/shape_borders/rectangle.dart
@@ -1,5 +1,4 @@
 import 'package:morphable_shape/src/common_includes.dart';
-import 'package:morphable_shape/src/ui_data_classes/dynamic_rectangle_styles.dart';
 
 ///Rectangle shape with various corner style and radius for each corner
 class RectangleShapeBorder extends OutlinedShapeBorder {
@@ -251,5 +250,5 @@ class RectangleShapeBorder extends OutlinedShapeBorder {
   }
 
   @override
-  int get hashCode => hashValues(border, cornerStyles, borderRadius);
+  int get hashCode => Object.hash(border, cornerStyles, borderRadius);
 }

--- a/lib/src/shape_borders/rounded_rectangle.dart
+++ b/lib/src/shape_borders/rounded_rectangle.dart
@@ -1,5 +1,4 @@
 import 'package:morphable_shape/src/common_includes.dart';
-import 'package:morphable_shape/src/ui_data_classes/dynamic_rectangle_styles.dart';
 
 ///Rectangle shape with various border radius and width for each corner
 ///This class is similar to what CSS box does, you can configure different border
@@ -324,5 +323,5 @@ class RoundedRectangleShapeBorder extends FilledBorderShapeBorder {
   }
 
   @override
-  int get hashCode => hashValues(borderSides, borderRadius);
+  int get hashCode => Object.hash(borderSides, borderRadius);
 }

--- a/lib/src/ui_data_classes/dynamic_border_radius.dart
+++ b/lib/src/ui_data_classes/dynamic_border_radius.dart
@@ -50,7 +50,7 @@ class DynamicRadius {
   }
 
   @override
-  int get hashCode => hashValues(x, y);
+  int get hashCode => Object.hash(x, y);
 }
 
 class DynamicBorderRadius {
@@ -125,5 +125,5 @@ class DynamicBorderRadius {
   }
 
   @override
-  int get hashCode => hashValues(topLeft, topRight, bottomLeft, bottomRight);
+  int get hashCode => Object.hash(topLeft, topRight, bottomLeft, bottomRight);
 }

--- a/lib/src/ui_data_classes/dynamic_border_side.dart
+++ b/lib/src/ui_data_classes/dynamic_border_side.dart
@@ -190,6 +190,6 @@ class DynamicBorderSide {
   }
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
       color, gradient, width, style, begin, end, shift, strokeJoin, strokeCap);
 }

--- a/lib/src/ui_data_classes/dynamic_offset.dart
+++ b/lib/src/ui_data_classes/dynamic_offset.dart
@@ -38,7 +38,7 @@ class DynamicOffset {
   }
 
   @override
-  int get hashCode => hashValues(dx, dy);
+  int get hashCode => Object.hash(dx, dy);
 
   @override
   bool operator ==(dynamic other) {

--- a/lib/src/ui_data_classes/shape_shadow.dart
+++ b/lib/src/ui_data_classes/shape_shadow.dart
@@ -139,7 +139,7 @@ class ShapeShadow extends ui.Shadow {
 
   @override
   int get hashCode =>
-      hashValues(color, gradient, offset, blurRadius, spreadRadius, blurStyle);
+      Object.hash(color, gradient, offset, blurRadius, spreadRadius, blurStyle);
 
   @override
   String toString() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.6.6
 repository: https://github.com/KevinVan720/morphable_shape
 
 environment:
-  sdk: ">=2.13.0 <4.0.0"
+  sdk: ">=2.14.0 <4.0.0"
   flutter: ">=2.10.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,9 @@ dependencies:
     sdk: flutter
 
   flutter_class_parser: ^0.2.5
-  dimension: ^0.1.7
+  dimension:
+    get:
+      url: https://github.com/KevinVan720/dimension.git
   animated_box_decoration: 0.0.7
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: morphable_shape
 description: A Flutter package for creating various shapes that are responsive and can morph betweem each other.
 version: 1.6.6
 repository: https://github.com/KevinVan720/morphable_shape
+publish_to: none
 
 environment:
   sdk: ">=2.14.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,9 @@ dependencies:
     sdk: flutter
 
   flutter_class_parser: ^0.2.5
-  dimension: ^0.1.7
+  dimension:
+    git:
+      url: https://github.com/KevinVan720/dimension.git
   animated_box_decoration: 0.0.7
 
 dev_dependencies:


### PR DESCRIPTION
- dart sdk: ">=2.14.0 <4.0.0"
- ran dart fix --apply
- replaced hashValue() with Object.hash()
- in decorated_shadowed_shape.dart file, the _ShapeBorderPaint class widget contained the final variable called borderOnForeground but it was not initialized in the constructor.